### PR TITLE
Fix ceilometer smoke test as a few metric tests were failing even though ceilometer was deployed correctly. [1/1]

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -112,7 +112,6 @@ unless node[:ceilometer][:use_gitrepo]
       package "ceilometer-common"
       package "ceilometer-collector"
       package "ceilometer-api"
-    end
   end
   venv_prefix = nil
 else


### PR DESCRIPTION
 smoketest/00-deploy-ceilometer.test |   29 ++++++++++++++++++-----------
 1 file changed, 18 insertions(+), 11 deletions(-)

Crowbar-Pull-ID: 1fb19bbaa8a4818b3b597be3e68db457ab9eec45

Crowbar-Release: pebbles
