### PR TITLE
Adjust Description to Telemetry

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -15,7 +15,7 @@
 barclamp:
   name: ceilometer
   display: Ceilometer
-  description: 'OpenStack Metering: measurements collection for monitoring and metering'
+  description: 'OpenStack Telemetry: Measurements collection for monitoring and metering'
   proposal_schema_version: 1
   version: 0
   requires:


### PR DESCRIPTION
Official OpenStack Naming was changed from Metering to Telemetry.
See
http://git.openstack.org/cgit/openstack/governance/commit/?id=9564eecb9769cb0fd52ff216b3e3172a6a323e3b
