### PR TITLE
Set Verbose Logging by Default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ceilometer.json
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.json
@@ -4,7 +4,7 @@
   "attributes": {
     "ceilometer": {
       "debug": false,
-      "verbose": false,
+      "verbose": true,
       "use_mongodb": true,
       "rabbitmq_instance": "none",
       "database_instance": "none",


### PR DESCRIPTION
This does not add that much more overhead to the actual logfiles,
but makes them tremendously more useful in case of unexpected
behavior happening.
