### PR TITLE
propose services for nodes according to intended role

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -110,9 +110,12 @@ class CeilometerService < ServiceObject
       raise(I18n.t('model.service.dependency_missing', :name => @bc_name, :dependson => "rabbitmq"))
     end
 
-    nodes        = NodeObject.all
-    agent_nodes  = nodes.select { |n| n.intended_role == "compute" }
-    server_nodes = nodes.select { |n| n.intended_role == "controller" }
+    agent_nodes = NodeObject.find("roles:nova-multi-compute-kvm") +
+                  NodeObject.find("roles:nova-multi-compute-qemu") +
+                  NodeObject.find("roles:nova-multi-compute-xen") +
+                  NodeObject.find("roles:nova-multi-compute-esxi")
+
+    server_nodes = NodeObject.all.select { |n| n.intended_role == "controller" }
 
     base["deployment"]["ceilometer"]["elements"] = {
         "ceilometer-agent" =>  agent_nodes.map { |x| x.name },


### PR DESCRIPTION
Use the intended role set for the nodes to propose ceilometer deployment.
(Requires changes in barclamp-crowbar: https://github.com/crowbar/barclamp-crowbar/pull/796)

SUSE reference: https://bugzilla.novell.com/show_bug.cgi?id=828816
