### PR TITLE
Updating tempest config to "havana", enabling volume metering

### DIFF
--- a/smoketest/00-deploy-ceilometer.test
+++ b/smoketest/00-deploy-ceilometer.test
@@ -39,11 +39,11 @@ export OS_TENANT_NAME="admin"
 export CEILOMETER_URL="http://$ceilometer_ip:8777"
 
 if [ -f /etc/redhat-release ]; then
-  sudo yum --assumeyes install python-ceilometerclient
+  sudo yum --assumeyes install python-ceilometerclient python-novaclient python-neutronclient
 elif [ -f /etc/SuSE-release ]; then
-  sudo zypper -n install python-ceilometerclient
+  sudo zypper -n install python-ceilometerclient python-novaclient python-neutronclient
 else
-  sudo apt-get install -y python-ceilometerclient
+  sudo apt-get install -y python-ceilometerclient python-novaclient python-neutronclient
 fi
 
 echo "Getting meter-list from ceilometer"
@@ -68,18 +68,28 @@ export CEILOMETER_API_VERSION=2
 echo "Deploying Nova VM."
 
 images=($(nova image-list | grep "ACTIVE" | grep "ubuntu" | grep "\-image" | awk '{print $2}'))
+echo $images
 [[ ! $images ]] && die 1 "Could not find a test image to run on Nova"
 test_image=${images[0]}
 echo -e  "Selected image id: $test_image"
 
 fixed_net=$(neutron net-list |grep fixed |awk '{print $2}')
 instance_name="smoketest"
-
+v_device="vdb"
+volume_name="smoketest_metering_target"
 echo "Adding smoke flavor"
 flavor_rnd=$(( 100 + $RANDOM % 100))
-nova flavor-create smoketest ${flavor_rnd} 512 2 1 || die 1 "Unable to create flavor"
+nova flavor-create smoketest-${flavor_rnd} ${flavor_rnd} 512 2 1 || die 1 "Unable to create flavor"
 
-nova boot --poll --image "$test_image" --flavor ${flavor_rnd} --nic net-id=$fixed_net "$instance_name" --meta description='Use for smoke testing purposes'
+nova volume-create --display_name $volume_name 2
+volume_id=$(nova volume-list | grep $volume_name | awk {'print $2'})
+nova boot --poll --image "$test_image" --flavor ${flavor_rnd} --nic net-id=$fixed_net "$instance_name" --meta description='Use for smoke testing purposes' && sleep 30
+instance_id=$(nova list | grep $instance_name | awk {'print $2'})
+echo -e "Instance_id:$instance_id\nVolume_id: $volume_id\nV_device:$v_device"
+nova volume-attach $instance_id  $volume_id /dev/$v_device && sleep 5
+
+
+
 
 until [[ "$(nova list | grep "$instance_name" | awk {'print $6'})" = "ACTIVE" ]]
   do
@@ -91,7 +101,7 @@ echo "Created $instance_name instance with ID: $instance_id"
 
 echo "Getting meter-list for test virtual machine from ceilometer"
 
-for meter in cpu cumulative disk.read.bytes disk.write.requests; do
+for meter in cpu disk.ephemeral.size disk.root.size memory; do
   isok="false"
   for ((i=1; i<=60; i++)); do
     metrics=$(ceilometer meter-list | grep "$instance_id")
@@ -112,12 +122,35 @@ for meter in cpu cumulative disk.read.bytes disk.write.requests; do
   fi
 done
 
+for meter in 'volume' 'volume\.size'; do
+  v_meter_ok="false"
+  for ((i=1; i<=60; i++)); do
+   echo -e "Processing metric: $meter"
+    v_metrics=$(ceilometer meter-list | grep "$meter " | grep "$volume_id" | awk {'print $8'})
+    if [[ $v_metrics ]]; then
+      echo "Successfully fetched meter: ${meter} resource_id: $v_metrics attempt ${i}"
+      v_meter_ok="true"
+      break
+    else
+      echo -ne "\r"
+      echo -ne "Failed to fetch ${meter} meter attempt ${i}/60"
+      #we need such huge timeout to be sure we fit into pipeline interval wich is 600 by default 20*60=1200
+      sleep 20
+    fi
+  done
+  echo ""
+  if [ "${v_meter_ok}" != "true" ] ; then
+    die 1 "Failed to fetch ${meter} meter"
+  fi
+done
+
 
 echo "$metrics";
-echo "Deleting Nova VM.";
+echo "Cleaning up...";
+nova volume-detach $instance_id $volume_id && sleep 5
 nova delete "$instance_id";
-nova flavor-delete smoketest
+nova volume-delete $volume_id
+nova flavor-delete smoketest-${flavor_rnd}
 
 echo "Ceilometer check passed.";
 exit 0
-

--- a/smoketest/README
+++ b/smoketest/README
@@ -1,10 +1,9 @@
-Ensuring that the cli commands run without error:
+Ensuring that the cli commands run without errors:
 1. meter list
 2. resource list
-3. project list
-4. sample list
-5. user list
+3. sample list
 
 Compute (Nova)
-1. check meter list available for a temporarily created instance
+1. verification of instance related metrics presence in smoketest instance meter-list
+2. verification of volume related metrics presence in smoketest instance meter-list
 


### PR DESCRIPTION
Following changes were made:
    - Readme actualization in accordance with API v2 functionality.
    - Adding cinder volume related metrics test to a ceilometer smoketest.

In order to work requires: https://github.com/crowbar/barclamp-cinder/pull/122
