### PR TITLE
access to swift

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -230,7 +230,7 @@ keystone_register "give ceilometer user access" do
   action :add_access
 end
 
-env_filter = " AND database_config_environment:database-config-#{node[:ceilometer][:database_instance]}"
+env_filter = " AND swift_config_environment:#{node[:swift][:config][:environment]}"
 swift_nodes = search(:node, "roles:swift-proxy#{env_filter}") || []
 unless swift_nodes.empty?
   keystone_register "give ceilometer user ResellerAdmin role" do


### PR DESCRIPTION
According to http://docs.openstack.org/developer/ceilometer/install/manual.html

ceilometer needs access to swift with ResellerAdmin role (itself created by swift-proxy).

I'm not sure if this keystone_register method is the correct one, someone  with better keystone knowledge should check this.

See also https://bugzilla.novell.com/show_bug.cgi?id=844044
