### PR TITLE
Configure Lock path for Ceilometer

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -143,7 +143,7 @@ libvirt_type=<%= node[:nova][:libvirt_type] %>
 #disable_process_locking=false
 
 # Directory to use for lock files. (string value)
-#lock_path=<None>
+lock_path=/var/lock/ceilometer
 
 
 #


### PR DESCRIPTION
Otherwise API and Central collector might run into
locking issues.
