### PR TITLE
Move to /var/run

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -143,7 +143,7 @@ libvirt_type=<%= node[:nova][:libvirt_type] %>
 #disable_process_locking=false
 
 # Directory to use for lock files. (string value)
-lock_path=/var/lock/ceilometer
+lock_path=/var/run/ceilometer
 
 
 #


### PR DESCRIPTION
/var/lock is blacklisted on openSUSE
