### PR TITLE
PostgreSQL backend is not implemented in Havana

### DIFF
--- a/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
@@ -10,7 +10,7 @@
     = integer_field :cpu_interval
     = integer_field :meters_interval
 
-    = boolean_field :use_mongodb
+    -# = boolean_field :use_mongodb
     = boolean_field :verbose
 
     = render "barclamp/git/pfsdeps"


### PR DESCRIPTION
It will come back in icehouse, or perhaps when patches are backported
sooner in havana,but at the moment the option doesn't make any sense.
