### PR TITLE
Fix: Cumulative metrics (CentOS)

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -1,6 +1,9 @@
 [DEFAULT]
 
+<% if %w{ubuntu}.include?(node['platform']) -%>
 host=<%= @node_hostname %>
+<% end -%>
+
 #
 # Options defined in ceilometer.middleware
 #


### PR DESCRIPTION
This is fix for gather cumulative metrics on CentOS.
Ceilometer requires specific host name on different distributives to match Nova compute with metrics
