### PR TITLE
Only give ResellerAdmin role to ceilometer after creation of user

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -231,6 +231,21 @@ keystone_register "give ceilometer user access" do
   action :add_access
 end
 
+env_filter = " AND ceilometer_config_environment:#{node[:ceilometer][:config][:environment]}"
+swift_middlewares = search(:node, "roles:ceilometer-swift-proxy-middleware#{env_filter}") || []
+unless swift_middlewares.empty?
+  keystone_register "give ceilometer user ResellerAdmin role" do
+    protocol keystone_protocol
+    host keystone_host
+    port keystone_admin_port
+    token keystone_token
+    user_name keystone_service_user
+    tenant_name keystone_service_tenant
+    role_name "ResellerAdmin"
+    action :add_access
+  end
+end
+
 # Create ceilometer service
 keystone_register "register ceilometer service" do
   protocol keystone_protocol

--- a/chef/cookbooks/ceilometer/recipes/swift.rb
+++ b/chef/cookbooks/ceilometer/recipes/swift.rb
@@ -49,18 +49,6 @@ keystone_service_tenant = keystone["keystone"]["service"]["tenant"]
 keystone_service_user = node["ceilometer"]["keystone_service_user"]
 Chef::Log.info("Keystone server found at #{keystone_host}")
 
-
-keystone_register "give ceilometer user ResellerAdmin role" do
-  protocol keystone_protocol
-  host keystone_host
-  port keystone_admin_port
-  token keystone_token
-  user_name keystone_service_user
-  tenant_name keystone_service_tenant
-  role_name "ResellerAdmin"
-  action :add_access
-end
-
 # swift user needs read access to ceilometer.conf
 group node[:ceilometer][:group] do
   action :modify


### PR DESCRIPTION
We were doing it too early:

[Wed, 19 Feb 2014 00:11:50 +0000] INFO: Processing keystone_register[give ceilometer user ResellerAdmin role] action add_access (ceilometer::swift line 53)
[Wed, 19 Feb 2014 00:11:50 +0000] ERROR: Find /v2.0/tenants/c07ee0519edd45c087397534a2c4e690/users//roles: ResellerAdmin: Unknown response from Keystone Server
[Wed, 19 Feb 2014 00:11:50 +0000] ERROR: Response Code: 404
[Wed, 19 Feb 2014 00:11:50 +0000] ERROR: Response Message: Not Found

(cherry picked from commit 8d8c177aaf64c9fff512d06a333b6079e8a00bd2)
