### PR TITLE
Update passwords migration script to remove node attributes

### DIFF
--- a/chef/data_bags/crowbar/migrate/ceilometer/004_generate_secrets.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/004_generate_secrets.rb
@@ -1,10 +1,41 @@
 def upgrade ta, td, a, d
+  # Old proposals had passwords created in the cookbook, so we need to migrate
+  # them in the proposal and in the role. We use a class variable to set the
+  # same password in the proposal and in the role.
   service = ServiceObject.new "fake-logger"
-  # old proposals had secrets created in the cookbook
-  if a['db']['password'].nil? || a['db']['password'].empty?
-    a['db']['password'] = service.random_password
+  unless defined?(@@ceilometer_db_password)
+    @@ceilometer_db_password = service.random_password
   end
-  a['metering_secret'] = service.random_password
+  unless defined?(@@ceilometer_metering_secret)
+    @@ceilometer_metering_secret = service.random_password
+  end
+
+  Chef::Search::Query.new.search(:node) do |node|
+    dirty = false
+    unless (node[:ceilometer][:db][:password] rescue nil).nil?
+      unless node[:ceilometer][:db][:password].empty?
+        @@ceilometer_db_password = node[:ceilometer][:db][:password]
+      end
+      node[:ceilometer][:db].delete('password')
+      dirty = true
+    end
+    unless (node[:ceilometer][:metering_secret] rescue nil).nil?
+      unless node[:ceilometer][:metering_secret].empty?
+        @@ceilometer_metering_secret = node[:ceilometer][:metering_secret]
+      end
+      node[:ceilometer].delete('metering_secret')
+      dirty = true
+    end
+    node.save if dirty
+  end
+
+  if a['db']['password'].nil? || a['db']['password'].empty?
+    a['db']['password'] = @@ceilometer_db_password
+  end
+  if a['metering_secret'].nil? || a['metering_secret'].empty?
+    a['metering_secret'] = @@ceilometer_metering_secret
+  end
+
   return a, d
 end
 


### PR DESCRIPTION
On update, we want to use the db password (and metering secret) from the
proposal / role, and not the ones that might have been generated on the node
(through the cookbook). As the passwords are a "normal" attribute on the node,
but a "default" attribute on the role, the old ones from the node is used.
Which means we really need to remove them to get the new ones used.

To minimize config changes, we actually import the passwords from one
node (which should be good enough in most cases as we allow only one
ceilometer proposal, so only one node should have the passwords).
