### PR TITLE
Use new CrowbarPacemakerHelper.is_cluster_founder? helper

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -16,7 +16,7 @@ if node[:ceilometer][:use_mongodb]
   db_hosts = search_env_filtered(:node, "roles:ceilometer-server")
   if node[:ceilometer][:ha][:server][:enabled]
     # Currently, we only setup mongodb non-HA on the first node
-    db_host = db_hosts.select { |n| n.roles.include?("pacemaker-cluster-founder") }.first
+    db_host = db_hosts.select { |n| CrowbarPacemakerHelper.is_cluster_founder?(n) }.first
   end
   db_host ||= db_hosts.first || node
 

--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -16,7 +16,7 @@
 ha_enabled = node[:ceilometer][:ha][:server][:enabled]
 
 if node[:ceilometer][:use_mongodb]
-  if !ha_enabled || node.roles.include?("pacemaker-cluster-founder")
+  if !ha_enabled || CrowbarPacemakerHelper.is_cluster_founder?(node)
     case node["platform"]
       when "centos", "redhat"
         mongo_conf = "/etc/mongod.conf"
@@ -48,7 +48,7 @@ if node[:ceilometer][:use_mongodb]
     # HA is enabled, and we're not the cluster founder
     # Currently, we only setup mongodb non-HA on the first node, so wait for this one...
     db_hosts = search_env_filtered(:node, "roles:ceilometer-server")
-    db_host = db_hosts.select { |n| n.roles.include?("pacemaker-cluster-founder") }.first
+    db_host = db_hosts.select { |n| CrowbarPacemakerHelper.is_cluster_founder?(n) }.first
     mongodb_address  = Chef::Recipe::Barclamp::Inventory.get_network_by_type(db_host, "admin").address
   end
 


### PR DESCRIPTION
Note: merging this means a rebase in https://github.com/crowbar/barclamp-ceilometer/pull/103 which will make @mapleoin's life a bit harder.

But in the mean time, it's required to totally kill the founder role.
