### PR TITLE
Pacemaker timeout

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -66,6 +66,8 @@ default[:ceilometer][:ha][:server][:enabled] = false
 
 default[:ceilometer][:ha][:api][:agent] = "lsb:#{api_service_name}"
 default[:ceilometer][:ha][:api][:op][:monitor][:interval] = "10s"
+# increase default timeout: ceilometer has to wait until mongodb is ready
+default[:ceilometer][:ha][:api][:op][:start][:timeout] = "60s"
 default[:ceilometer][:ha][:collector][:agent] = "lsb:#{collector_service_name}"
 default[:ceilometer][:ha][:collector][:op][:monitor][:interval] = "10s"
 

--- a/chef/cookbooks/ceilometer/recipes/central_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/central_ha.rb
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 
-# Wait for all nodes to reach this point so we know that all nodes will have
-# all the required packages installed before we create the pacemaker
-# resources
+# Wait for all nodes to reach this point so we know that they will have
+# all the required packages installed and configuration files updated
+# before we create the pacemaker resources.
 crowbar_pacemaker_sync_mark "sync-ceilometer_central_before_ha"
 
 # Avoid races when creating pacemaker resources

--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -21,9 +21,9 @@ haproxy_loadbalancer "ceilometer-api" do
   action :nothing
 end.run_action(:create)
 
-# Wait for all nodes to reach this point so we know that all nodes will have
-# all the required packages installed before we create the pacemaker
-# resources
+# Wait for all nodes to reach this point so we know that they will have
+# all the required packages installed and configuration files updated
+# before we create the pacemaker resources.
 crowbar_pacemaker_sync_mark "sync-ceilometer_server_before_ha"
 
 # Avoid races when creating pacemaker resources


### PR DESCRIPTION
Set timeout when creating pacemaker primitives, because it may take time until they are able to connect to mongodb.
