### PR TITLE
ceilometer-server role needs at least 3 nodes in a cluster

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -108,6 +108,8 @@ class CeilometerService < PacemakerServiceObject
       validate_dep_proposal_is_active "git", proposal["attributes"][@bc_name]["git_instance"]
     end
 
+    validate_minimum_three_nodes_in_cluster(proposal)
+
     swift_proxy_nodes = NodeObject.find("roles:swift-proxy").map { |x| x.name }
     proposal["deployment"]["ceilometer"]["elements"]["ceilometer-swift-proxy-middleware"].each do |n|
       unless swift_proxy_nodes.include? n
@@ -148,4 +150,27 @@ class CeilometerService < PacemakerServiceObject
     @logger.debug("Ceilometer apply_role_pre_chef_call: leaving")
   end
 
+  private
+
+  # If the ceilometer-server role has a cluster assigned, we want to
+  # make sure that the cluster contains at least three nodes. MongoDB HA
+  # requires it; otherwise the Replica Set wouldn't be able to elect a
+  # primary.
+  def validate_minimum_three_nodes_in_cluster(proposal)
+    servers = proposal["deployment"][@bc_name]["elements"]["ceilometer-server"]
+    use_mongodb = proposal["attributes"][@bc_name]["use_mongodb"]
+
+    if use_mongodb && servers.length == 1 && is_cluster?(servers[0])
+      nodes, failures = expand_nodes_for_all servers
+
+      @logger.debug("validate_minimum_three_nodes_in_cluster: skipping "\
+        "items that we failed to expand: #{failures.join(", ")}"
+        ) unless failures.nil? || failures.empty?
+
+      validation_error(
+        "The cluster assigned to the ceilometer-server "\
+        "role should have at least 3 nodes, but it only has #{nodes.count}."
+        ) if nodes.length < 3
+    end
+  end
 end


### PR DESCRIPTION
This is needed for the ceilometer HA functionality. It is related, but does not depend on #103
