### PR TITLE
Configure ceilometer compute agent for vsphere

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -49,6 +49,16 @@ else
   db_connection = "#{backend_name}://#{node[:ceilometer][:db][:user]}:#{db_password}@#{sql_address}/#{node[:ceilometer][:db][:database]}"
 end
 
+# Find hypervisor inspector
+hypervisor_inspector = nil
+if node.roles.include?("ceilometer-agent")
+  if node.roles.include?("nova-multi-compute-vmware")
+    hypervisor_inspector = "vsphere"
+  else
+    hypervisor_inspector = "libvirt"
+  end
+end
+
 if node[:ceilometer][:ha][:server][:enabled]
   admin_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
   bind_host = admin_address
@@ -72,7 +82,8 @@ template "/etc/ceilometer/ceilometer.conf" do
       :bind_port => bind_port,
       :metering_secret => node[:ceilometer][:metering_secret],
       :database_connection => db_connection,
-      :node_hostname => node['hostname']
+      :node_hostname => node['hostname'],
+      :hypervisor_inspector => hypervisor_inspector
     )
 end
 

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -88,8 +88,7 @@ host=<%= @node_hostname %>
 # Inspector to use for inspecting the hypervisor layer.
 # (string value)
 #hypervisor_inspector=libvirt
-<% if defined?(node[:nova][:libvirt_type]) -%>
-hypervisor_inspector=libvirt
+hypervisor_inspector=<%= @hypervisor_inspector %>
 
 #
 # Options defined in ceilometer.compute.virt.libvirt.inspector
@@ -102,7 +101,6 @@ libvirt_type=<%= node[:nova][:libvirt_type] %>
 # Override the default libvirt URI (which is dependent on
 # libvirt_type). (string value)
 #libvirt_uri=
-<% end -%>
 
 #
 # Options defined in ceilometer.image.notifications
@@ -1005,13 +1003,13 @@ insecure= <%= @keystone_settings['insecure'] %>
 #
 
 # IP address of the VMware Vsphere host (string value)
-#host_ip=
+host_ip=<%= node[:nova][:vcenter][:host] rescue "" %>
 
 # Username of VMware Vsphere (string value)
-#host_username=
+host_username=<%= node[:nova][:vcenter][:user] rescue "" %>
 
 # Password of VMware Vsphere (string value)
-#host_password=
+host_password=<%= node[:nova][:vcenter][:password] rescue "" %>
 
 # Number of times a VMware Vsphere API must be retried
 # (integer value)


### PR DESCRIPTION
When running on a nova node that is a proxy for vsphere, ceilometer
should not be configured for libvirt.
