### PR TITLE
Increase CLI timeout (bnc#884018)

### DIFF
--- a/bin/crowbar_ceilometer
+++ b/bin/crowbar_ceilometer
@@ -18,5 +18,6 @@
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
 @barclamp = "ceilometer"
+@timeout = 3600
 
 main


### PR DESCRIPTION
To prevent timeout errors that have been descibed within
https://bugzilla.novell.com/show_bug.cgi?id=884018 i have simply
increased the timeout as for multiple other barclamps as well.
