### PR TITLE
Add new attribute to define threshold alarm evaluation interval

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -83,7 +83,8 @@ template "/etc/ceilometer/ceilometer.conf" do
       :metering_secret => node[:ceilometer][:metering_secret],
       :database_connection => db_connection,
       :node_hostname => node['hostname'],
-      :hypervisor_inspector => hypervisor_inspector
+      :hypervisor_inspector => hypervisor_inspector,
+      :alarm_threshold_evaluation_interval => node[:ceilometer][:alarm_threshold_evaluation_interval]
     )
 end
 

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -571,7 +571,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # pipeline interval for collection of underlying metrics.
 # (integer value)
 # Deprecated group/name - [alarm]/threshold_evaluation_interval
-#evaluation_interval=60
+threshold_evaluation_interval=<%= @alarm_threshold_evaluation_interval %>
 
 
 #

--- a/chef/data_bags/crowbar/bc-template-ceilometer.json
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.json
@@ -6,6 +6,7 @@
       "debug": false,
       "verbose": true,
       "use_mongodb": true,
+      "alarm_threshold_evaluation_interval": 600,
       "cpu_interval": 600,
       "disk_interval": 600,
       "network_interval": 600,
@@ -43,7 +44,7 @@
     "ceilometer": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 12,
       "element_states": {
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-cagent": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/bc-template-ceilometer.schema
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.schema
@@ -15,6 +15,7 @@
             "debug": { "type": "bool", "required": true },
             "verbose": { "type": "bool", "required": true },
             "use_mongodb": { "type": "bool", "required": true },
+            "alarm_threshold_evaluation_interval": { "type": "int", "required": true },
             "cpu_interval": { "type": "int", "required": true },
             "disk_interval": { "type": "int", "required": true },
             "network_interval": { "type": "int", "required": true },

--- a/chef/data_bags/crowbar/migrate/ceilometer/012_add_intervals_for_alarm_evaluation.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/012_add_intervals_for_alarm_evaluation.rb
@@ -1,0 +1,12 @@
+def upgrade ta, td, a, d
+  a['alarm_threshold_evaluation_interval'] = [ a['cpu_interval'],
+                                               a['disk_interval'],
+                                               a['network_interval'],
+                                               a['meters_interval'] ].max
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('alarm_threshold_evaluation_interval')
+  return a, d
+end

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -117,6 +117,13 @@ class CeilometerService < PacemakerServiceObject
       end
     end
 
+    alarm_eval_interval = proposal["attributes"][@bc_name]["alarm_threshold_evaluation_interval"]
+    ["cpu_interval", "disk_interval", "network_interval", "meters_interval"].each do |i|
+      if alarm_eval_interval < proposal["attributes"][@bc_name][i]
+        validation_error("The threshold alarm evaluation interval needs be greater than (or equal to) all the meter update intervals.")
+        break
+      end
+    end
     super
   end
 

--- a/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ceilometer/_edit_attributes.html.haml
@@ -11,6 +11,7 @@
     = integer_field :disk_interval
     = integer_field :network_interval
     = integer_field :meters_interval
+    = integer_field :alarm_threshold_evaluation_interval
 
     = boolean_field :use_mongodb
     = boolean_field :verbose

--- a/crowbar_framework/config/locales/ceilometer/en.yml
+++ b/crowbar_framework/config/locales/ceilometer/en.yml
@@ -24,6 +24,7 @@ en:
         database_instance: 'Database'
         keystone_instance: 'Keystone'
         rabbitmq_instance: 'RabbitMQ'
+        alarm_threshold_evaluation_interval: 'Evaluation interval for threshold alarms (in seconds).'
         cpu_interval: 'Interval used for CPU meter updates (in seconds)'
         disk_interval: 'Interval used for disk meter updates (in seconds)'
         network_interval: 'Interval used for network meter updates (in seconds)'


### PR DESCRIPTION
Also make sure that this interval is >= than the other metering intervals.
Otherwise alarming doesn't work correctly.
