### PR TITLE
prevent crash when removing nova-compute role from a node

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -89,7 +89,7 @@ template "/etc/ceilometer/ceilometer.conf" do
       :libvirt_type => libvirt_type,
       :alarm_threshold_evaluation_interval => node[:ceilometer][:alarm_threshold_evaluation_interval]
     )
-    if node.roles.include?("ceilometer-agent")
+    if node.roles.include?("ceilometer-agent") && node.roles.include?("nova-multi-compute-#{libvirt_type}")
       notifies :restart, "service[nova-compute]"
     end
 end
@@ -105,7 +105,7 @@ template "/etc/ceilometer/pipeline.yaml" do
       :disk_interval => node[:ceilometer][:disk_interval],
       :network_interval => node[:ceilometer][:network_interval]
   })
-  if node.roles.include?("ceilometer-agent")
+  if node.roles.include?("ceilometer-agent") && node.roles.include?("nova-multi-compute-#{libvirt_type}")
     notifies :restart, "service[nova-compute]"
   end
 end


### PR DESCRIPTION
This crash, that was fixed in the [last commit](https://github.com/crowbar/barclamp-ceilometer/commit/d0aaa0347af276d74b407f3428fca52387c9ee03#diff-d41d8cd98f00b204e9800998ecf8427e) remains when you remove the `nova-multi-compute` role from a node, probably because of the nova attributes still in the node object. until the proper role deactivation is not yet implemented this needs some workaround.
