### PR TITLE
Make config files owned by root:ceilometer, instead of ceilometer:ceilom...

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -85,8 +85,8 @@ end
 template "/etc/ceilometer/pipeline.yaml" do
   source "pipeline.yaml.erb"
   owner "root"
-  group node[:ceilometer][:group]
-  mode "0640"
+  group "root"
+  mode "0644"
   variables({
       :meters_interval => node[:ceilometer][:meters_interval],
       :cpu_interval => node[:ceilometer][:cpu_interval],


### PR DESCRIPTION
...eter

We don't want the ceilometer user to be able to write the files.
