### PR TITLE
With HA, really look for mongodb master on all nodes

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -22,7 +22,7 @@ if node[:ceilometer][:use_mongodb]
   # (ceilometer services need it running)
   mongodb_nodes = nil
 
-  if ha_enabled && !node[:ceilometer][:ha][:mongodb][:replica_set][:member]
+  if ha_enabled
     mongodb_nodes = search(:node,
       "ceilometer_ha_mongodb_replica_set_member:true AND "\
       "ceilometer_config_environment:#{node[:ceilometer][:config][:environment]}"


### PR DESCRIPTION
We were only looking at the current node, unless the current node was
not part of the replica set. That's obviously broken if the current node
is part of the replica set, but not the master.
