### PR TITLE
Fix shell out failing due to a missing require

### DIFF
--- a/chef/cookbooks/ceilometer/libraries/mongodb.rb
+++ b/chef/cookbooks/ceilometer/libraries/mongodb.rb
@@ -23,7 +23,7 @@
 # original at: https://github.com/edelight/chef-mongodb/blob/master/libraries/mongodb.rb
 
 require 'json'
-
+include Chef::Mixin::ShellOut
 
 module CeilometerHelper
   class << self


### PR DESCRIPTION
(cherry picked from commit 31988c4c998d56d6b00f54e61835f701aeb6fb83)
