### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server.rb
+++ b/chef/cookbooks/ceilometer/recipes/server.rb
@@ -316,7 +316,7 @@ keystone_register "register ceilometer endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "ceilometer"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{node[:ceilometer][:api][:protocol]}://#{my_public_host}:#{node[:ceilometer][:api][:port]}"
   endpoint_adminURL "#{node[:ceilometer][:api][:protocol]}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"
   endpoint_internalURL "#{node[:ceilometer][:api][:protocol]}://#{my_admin_host}:#{node[:ceilometer][:api][:port]}"

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -966,7 +966,7 @@ os_auth_url=<%= @keystone_settings['internal_auth_url'] %>
 
 # Region name to use for OpenStack service endpoints. (string
 # value)
-#os_region_name=<None>
+os_region_name=<%= @keystone_settings['endpoint_region'] %>
 
 # Type of endpoint in Identity service catalog to use for
 # communication with OpenStack services. (string value)


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
