### PR TITLE
Fix cagent proposal default

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -89,8 +89,8 @@ class CeilometerService < PacemakerServiceObject
 
     base["deployment"]["ceilometer"]["elements"] = {
         "ceilometer-agent" =>  agent_nodes.map { |x| x.name },
-        "ceilometer-cagent" =>  server_nodes.map { |x| x.name },
-        "ceilometer-server" =>  server_nodes.map { |x| x.name },
+        "ceilometer-cagent" =>  server_nodes.first.name,
+        "ceilometer-server" =>  server_nodes.first.name,
         "ceilometer-swift-proxy-middleware" =>  swift_proxy_nodes.map { |x| x.name }
     } unless agent_nodes.nil? or server_nodes.nil?
 


### PR DESCRIPTION
When multiple nodes are marked as controller, the default
proposal of ceilometer does not validate. That is because
cagent can only receive one node. So select the first
controller node as the cagent node.