### PR TITLE
Adapt rubygem-mongo to the new name schema

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/mongodb.rb
+++ b/chef/cookbooks/ceilometer/recipes/mongodb.rb
@@ -64,7 +64,12 @@ if ha_enabled
   if node[:ceilometer][:ha][:mongodb][:replica_set][:controller]
     # install the package immediately because we need it to configure the
     # replicaset
-    package("rubygem-mongo").run_action(:install)
+    if node["platform"] == "suse" && node["platform_version"].to_f >= 12 ||
+       node["platform"] == "opensuse" && node["platform_version"].to_f >= 13.2
+      package("ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-mongo").run_action(:install)
+    else
+      package("rubygem-mongo").run_action(:install)
+    end
 
     members = search(:node,
       "ceilometer_ha_mongodb_replica_set_member:true AND "\


### PR DESCRIPTION
Use the new schema for rubygem in SLE12 and openSUSE 13.2.
