### PR TITLE
Store the value of time to live in days, instead of seconds

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -70,6 +70,12 @@ else
   bind_port = node[:ceilometer][:api][:port]
 end
 
+time_to_live = node[:ceilometer][:database][:time_to_live]
+if time_to_live > 0
+  # We store the value of time to live in days, but config file expects seconds
+  time_to_live = time_to_live * 3600 * 24
+end
+
 template "/etc/ceilometer/ceilometer.conf" do
     source "ceilometer.conf.erb"
     owner "root"
@@ -87,6 +93,7 @@ template "/etc/ceilometer/ceilometer.conf" do
       :node_hostname => node['hostname'],
       :hypervisor_inspector => hypervisor_inspector,
       :libvirt_type => libvirt_type,
+      :time_to_live => time_to_live,
       :alarm_threshold_evaluation_interval => node[:ceilometer][:alarm_threshold_evaluation_interval]
     )
     if is_compute_agent

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -695,7 +695,7 @@ connection=<%= @database_connection %>
 
 # Number of seconds that samples are kept in the database for
 # (<= 0 means forever). (integer value)
-time_to_live=<%= node[:ceilometer][:database][:time_to_live] %>
+time_to_live=<%= @time_to_live %>
 
 
 [dispatcher_file]

--- a/chef/data_bags/crowbar/bc-template-ceilometer.json
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.json
@@ -39,7 +39,7 @@
         "database": "ceilometer"
       },
       "database": {
-        "time_to_live": -1
+        "time_to_live": 30
       }
     }
   },

--- a/crowbar_framework/config/locales/ceilometer/en.yml
+++ b/crowbar_framework/config/locales/ceilometer/en.yml
@@ -32,5 +32,5 @@ en:
         use_mongodb: 'Use MongoDB instead of standard database'
         verbose: 'Verbose Logging'
         database:
-          time_to_live: 'How long are samples kept in the database (in seconds)'
+          time_to_live: 'How long are samples kept in the database (in days)'
           time_to_live_hint: '-1 means that samples are kept in the database forever'


### PR DESCRIPTION
Store the value of time to live in days, instead of seconds
to make it more user friendly.

Based on @dirkmueller suggestions in https://github.com/crowbar/barclamp-ceilometer/pull/162
