### PR TITLE
Update to juno

### DIFF
--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -1,6 +1,192 @@
 [DEFAULT]
 
 #
+# Options defined in oslo.messaging
+#
+
+# Use durable queues in AMQP. (boolean value)
+# Deprecated group/name - [DEFAULT]/rabbit_durable_queues
+#amqp_durable_queues=false
+
+# Auto-delete queues in AMQP. (boolean value)
+#amqp_auto_delete=false
+
+# Size of RPC connection pool. (integer value)
+#rpc_conn_pool_size=30
+
+# Qpid broker hostname. (string value)
+#qpid_hostname=localhost
+
+# Qpid broker port. (integer value)
+#qpid_port=5672
+
+# Qpid HA cluster host:port pairs. (list value)
+#qpid_hosts=$qpid_hostname:$qpid_port
+
+# Username for Qpid connection. (string value)
+#qpid_username=
+
+# Password for Qpid connection. (string value)
+#qpid_password=
+
+# Space separated list of SASL mechanisms to use for auth.
+# (string value)
+#qpid_sasl_mechanisms=
+
+# Seconds between connection keepalive heartbeats. (integer
+# value)
+#qpid_heartbeat=60
+
+# Transport to use, either 'tcp' or 'ssl'. (string value)
+#qpid_protocol=tcp
+
+# Whether to disable the Nagle algorithm. (boolean value)
+#qpid_tcp_nodelay=true
+
+# The number of prefetched messages held by receiver. (integer
+# value)
+#qpid_receiver_capacity=1
+
+# The qpid topology version to use.  Version 1 is what was
+# originally used by impl_qpid.  Version 2 includes some
+# backwards-incompatible changes that allow broker federation
+# to work.  Users should update to version 2 when they are
+# able to take everything down, as it requires a clean break.
+# (integer value)
+#qpid_topology_version=1
+
+# SSL version to use (valid only if SSL enabled). valid values
+# are TLSv1 and SSLv23. SSLv2 and SSLv3 may be available on
+# some distributions. (string value)
+#kombu_ssl_version=
+
+# SSL key file (valid only if SSL enabled). (string value)
+#kombu_ssl_keyfile=
+
+# SSL cert file (valid only if SSL enabled). (string value)
+#kombu_ssl_certfile=
+
+# SSL certification authority file (valid only if SSL
+# enabled). (string value)
+#kombu_ssl_ca_certs=
+
+# How long to wait before reconnecting in response to an AMQP
+# consumer cancel notification. (floating point value)
+#kombu_reconnect_delay=1.0
+
+# The RabbitMQ broker address where a single node is used.
+# (string value)
+rabbit_host=<%= @rabbit_settings[:address] %>
+
+# The RabbitMQ broker port where a single node is used.
+# (integer value)
+rabbit_port=<%= @rabbit_settings[:port] %>
+
+# RabbitMQ HA cluster host:port pairs. (list value)
+#rabbit_hosts=$rabbit_host:$rabbit_port
+
+# Connect over SSL for RabbitMQ. (boolean value)
+#rabbit_use_ssl=false
+
+# The RabbitMQ userid. (string value)
+rabbit_userid=<%= @rabbit_settings[:user] %>
+
+# The RabbitMQ password. (string value)
+rabbit_password=<%= @rabbit_settings[:password] %>
+
+# The RabbitMQ login method. (string value)
+#rabbit_login_method=AMQPLAIN
+
+# The RabbitMQ virtual host. (string value)
+rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
+
+# How frequently to retry connecting with RabbitMQ. (integer
+# value)
+#rabbit_retry_interval=1
+
+# How long to backoff for between retries when connecting to
+# RabbitMQ. (integer value)
+#rabbit_retry_backoff=2
+
+# Maximum number of RabbitMQ connection retries. Default is 0
+# (infinite retry count). (integer value)
+#rabbit_max_retries=0
+
+# Use HA queues in RabbitMQ (x-ha-policy: all). If you change
+# this option, you must wipe the RabbitMQ database. (boolean
+# value)
+#rabbit_ha_queues=false
+
+# Deprecated, use rpc_backend=kombu+memory or rpc_backend=fake
+# (boolean value)
+#fake_rabbit=false
+
+# ZeroMQ bind address. Should be a wildcard (*), an ethernet
+# interface, or IP. The "host" option should point or resolve
+# to this address. (string value)
+#rpc_zmq_bind_address=*
+
+# MatchMaker driver. (string value)
+#rpc_zmq_matchmaker=oslo.messaging._drivers.matchmaker.MatchMakerLocalhost
+
+# ZeroMQ receiver listening port. (integer value)
+#rpc_zmq_port=9501
+
+# Number of ZeroMQ contexts, defaults to 1. (integer value)
+#rpc_zmq_contexts=1
+
+# Maximum number of ingress messages to locally buffer per
+# topic. Default is unlimited. (integer value)
+#rpc_zmq_topic_backlog=<None>
+
+# Directory for holding IPC sockets. (string value)
+#rpc_zmq_ipc_dir=/var/run/openstack
+
+# Name of this node. Must be a valid hostname, FQDN, or IP
+# address. Must match "host" option, if running Nova. (string
+# value)
+#rpc_zmq_host=ceilometer
+
+# Seconds to wait before a cast expires (TTL). Only supported
+# by impl_zmq. (integer value)
+#rpc_cast_timeout=30
+
+# Heartbeat frequency. (integer value)
+#matchmaker_heartbeat_freq=300
+
+# Heartbeat time-to-live. (integer value)
+#matchmaker_heartbeat_ttl=600
+
+# Size of RPC greenthread pool. (integer value)
+#rpc_thread_pool_size=64
+
+# Driver or drivers to handle sending notifications. (multi
+# valued)
+#notification_driver=
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+#notification_topics=notifications
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout=60
+
+# A URL representing the messaging driver to use and its full
+# configuration. If not set, we fall back to the rpc_backend
+# option and driver specific configuration. (string value)
+#transport_url=<None>
+
+# The messaging driver to use, defaults to rabbit. Other
+# drivers include qpid and zmq. (string value)
+#rpc_backend=rabbit
+
+# The default exchange under which topics are scoped. May be
+# overridden by an exchange name specified in the
+# transport_url option. (string value)
+#control_exchange=openstack
+
+
+#
 # Options defined in ceilometer.middleware
 #
 
@@ -9,6 +195,14 @@
 #http_control_exchanges=glance
 #http_control_exchanges=neutron
 #http_control_exchanges=cinder
+
+
+#
+# Options defined in ceilometer.nova_client
+#
+
+# Allow novaclient's debug log output. (boolean value)
+nova_http_log_debug=<%= @debug ? "true" : "false" %>
 
 
 #
@@ -37,28 +231,35 @@
 # host name, FQDN, or IP address. (string value)
 host=<%= @node_hostname %>
 
-# Dispatcher to process data. (multi valued)
-#dispatcher=database
-
-# Number of workers for collector service. A single
-# collector is enabled by default. (integer value)
+# Number of workers for collector service. A single collector
+# is enabled by default. (integer value)
 #collector_workers=1
 
 # Number of workers for notification service. A single
 # notification agent is enabled by default. (integer value)
 #notification_workers=1
 
+# Timeout seconds for HTTP requests. Set it to None to disable
+# timeout. (integer value)
+#http_timeout=600
+
+
+#
+# Options defined in ceilometer.utils
+#
+
+# Path to the rootwrap configuration file touse for running
+# commands as root (string value)
+#rootwrap_config=/etc/ceilometer/rootwrap.conf
+
 
 #
 # Options defined in ceilometer.api.app
 #
 
-# The strategy to use for auth: noauth or keystone. (string
+# Configuration file for WSGI definition of API. (string
 # value)
-#auth_strategy=keystone
-
-# Deploy the deprecated v1 API. (boolean value)
-#enable_v1_api=true
+#api_paste_config=api_paste.ini
 
 
 #
@@ -90,6 +291,7 @@ host=<%= @node_hostname %>
 #hypervisor_inspector=libvirt
 hypervisor_inspector=<%= @hypervisor_inspector %>
 
+
 #
 # Options defined in ceilometer.compute.virt.libvirt.inspector
 #
@@ -102,12 +304,57 @@ libvirt_type=<%= @libvirt_type %>
 # libvirt_type). (string value)
 #libvirt_uri=
 
+
+#
+# Options defined in ceilometer.data_processing.notifications
+#
+
+# Exchange name for Data Processing notifications (string
+# value)
+#sahara_control_exchange=sahara
+
+
+#
+# Options defined in ceilometer.dispatcher
+#
+
+# Dispatcher to process data. (multi valued)
+#dispatcher=database
+
+
+#
+# Options defined in ceilometer.identity.notifications
+#
+
+# Exchange name for Keystone notifications. (string value)
+#keystone_control_exchange=keystone
+
+
+#
+# Options defined in ceilometer.image.glance
+#
+
+# Number of items to request in each paginated Glance API
+# request (parameter used by glancecelient). If this is less
+# than or equal to 0, page size is not specified (default
+# value in glanceclient is used). (integer value)
+#glance_page_size=0
+
+
 #
 # Options defined in ceilometer.image.notifications
 #
 
 # Exchange name for Glance notifications. (string value)
 #glance_control_exchange=glance
+
+
+#
+# Options defined in ceilometer.ipmi.notifications.ironic
+#
+
+# Exchange name for Ironic notifications. (string value)
+#ironic_exchange=ironic
 
 
 #
@@ -129,17 +376,6 @@ libvirt_type=<%= @libvirt_type %>
 
 
 #
-# Options defined in ceilometer.openstack.common.db.sqlalchemy.session
-#
-
-# The file name to use with SQLite (string value)
-#sqlite_db=ceilometer.sqlite
-
-# If True, SQLite uses synchronous mode (boolean value)
-#sqlite_synchronous=true
-
-
-#
 # Options defined in ceilometer.openstack.common.eventlet_backdoor
 #
 
@@ -158,7 +394,7 @@ libvirt_type=<%= @libvirt_type %>
 # Options defined in ceilometer.openstack.common.lockutils
 #
 
-# Whether to disable inter-process locks. (boolean value)
+# Enables or disables inter-process locks. (boolean value)
 #disable_process_locking=false
 
 # Directory to use for lock files. (string value)
@@ -177,47 +413,49 @@ debug=<%= @debug ? "True" : "False" %>
 # of default WARNING level). (boolean value)
 verbose=<%= @verbose ? "True" : "False" %>
 
-# Log output to standard error (boolean value)
+# Log output to standard error. (boolean value)
+#use_stderr=true
 use_stderr=false
 
-# Format string to use for log messages with context (string
+# Format string to use for log messages with context. (string
 # value)
 #logging_context_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
 
-# Format string to use for log messages without context
+# Format string to use for log messages without context.
 # (string value)
 #logging_default_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
 
-# Data to append to log format when level is DEBUG (string
+# Data to append to log format when level is DEBUG. (string
 # value)
 #logging_debug_format_suffix=%(funcName)s %(pathname)s:%(lineno)d
 
-# Prefix each line of exception output with this format
+# Prefix each line of exception output with this format.
 # (string value)
 #logging_exception_prefix=%(asctime)s.%(msecs)03d %(process)d TRACE %(name)s %(instance)s
 
-# List of logger=LEVEL pairs (list value)
+# List of logger=LEVEL pairs. (list value)
 #default_log_levels=amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN
 
-# Publish error events (boolean value)
+# Enables or disables publication of error events. (boolean
+# value)
 #publish_errors=false
 
-# Make deprecations fatal (boolean value)
+# Enables or disables fatal status of deprecations. (boolean
+# value)
 #fatal_deprecations=false
 
-# If an instance is passed with the log message, format it
-# like this (string value)
+# The format for an instance that is passed with the log
+# message. (string value)
 #instance_format="[instance: %(uuid)s] "
 
-# If an instance UUID is passed with the log message, format
-# it like this (string value)
+# The format for an instance UUID that is passed with the log
+# message. (string value)
 #instance_uuid_format="[instance: %(uuid)s] "
 
-# The name of logging configuration file. It does not disable
-# existing loggers, but just appends specified logging
-# configuration to any other existing logging options. Please
-# see the Python logging module documentation for details on
-# logging configuration files. (string value)
+# The name of a logging configuration file. This file is
+# appended to any existing logging configuration files. For
+# details about logging configuration files, see the Python
+# logging module documentation. (string value)
 # Deprecated group/name - [DEFAULT]/log_config
 #log_config_append=<None>
 
@@ -229,7 +467,7 @@ use_stderr=false
 #log_format=<None>
 
 # Format string for %%(asctime)s in log records. Default:
-# %(default)s (string value)
+# %(default)s . (string value)
 #log_date_format=%Y-%m-%d %H:%M:%S
 
 # (Optional) Name of log file to output to. If no default is
@@ -238,259 +476,37 @@ use_stderr=false
 #log_file=<None>
 
 # (Optional) The base directory used for relative --log-file
-# paths (string value)
+# paths. (string value)
 # Deprecated group/name - [DEFAULT]/logdir
+#log_dir=<None>
 log_dir=/var/log/ceilometer
 
 # Use syslog for logging. Existing syslog format is DEPRECATED
-# during I, and then will be changed in J to honor RFC5424
-# (boolean value)
+# during I, and will change in J to honor RFC5424. (boolean
+# value)
 #use_syslog=false
 
-# (Optional) Use syslog rfc5424 format for logging. If
-# enabled, will add APP-NAME (RFC5424) before the MSG part of
-# the syslog message.  The old format without APP-NAME is
-# deprecated in I, and will be removed in J. (boolean value)
+# (Optional) Enables or disables syslog rfc5424 format for
+# logging. If enabled, prefixes the MSG part of the syslog
+# message with APP-NAME (RFC5424). The format without the APP-
+# NAME is deprecated in I, and will be removed in J. (boolean
+# value)
 #use_syslog_rfc_format=false
 
-# Syslog facility to receive log lines (string value)
+# Syslog facility to receive log lines. (string value)
 #syslog_log_facility=LOG_USER
-
-
-#
-# Options defined in ceilometer.openstack.common.middleware.sizelimit
-#
-
-# The maximum body size per request, in bytes (integer value)
-# Deprecated group/name - [DEFAULT]/osapi_max_request_body_size
-#max_request_body_size=114688
-
-
-#
-# Options defined in ceilometer.openstack.common.notifier.api
-#
-
-# Driver or drivers to handle sending notifications (multi
-# valued)
-#notification_driver=
-
-# Default notification level for outgoing notifications
-# (string value)
-#default_notification_level=INFO
-
-# Default publisher_id for outgoing notifications (string
-# value)
-#default_publisher_id=<None>
-
-
-#
-# Options defined in ceilometer.openstack.common.notifier.rpc_notifier
-#
-
-# AMQP topic used for OpenStack notifications (list value)
-#notification_topics=notifications
 
 
 #
 # Options defined in ceilometer.openstack.common.policy
 #
 
-# JSON file containing policy (string value)
+# The JSON file that defines policies. (string value)
 #policy_file=policy.json
 
-# Rule enforced when requested rule is not found (string
-# value)
+# Default rule. Enforced when a requested rule is not found.
+# (string value)
 #policy_default_rule=default
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc
-#
-
-# The messaging module to use, defaults to kombu. (string
-# value)
-#rpc_backend=ceilometer.openstack.common.rpc.impl_kombu
-
-# Size of RPC thread pool (integer value)
-#rpc_thread_pool_size=64
-
-# Size of RPC connection pool (integer value)
-#rpc_conn_pool_size=30
-
-# Seconds to wait for a response from call or multicall
-# (integer value)
-#rpc_response_timeout=60
-
-# Seconds to wait before a cast expires (TTL). Only supported
-# by impl_zmq. (integer value)
-#rpc_cast_timeout=30
-
-# Modules of exceptions that are permitted to be recreated
-# upon receiving exception data from an rpc call. (list value)
-#allowed_rpc_exception_modules=nova.exception,cinder.exception,exceptions
-
-# If passed, use a fake RabbitMQ provider (boolean value)
-#fake_rabbit=false
-
-# AMQP exchange to connect to if using RabbitMQ or Qpid
-# (string value)
-#control_exchange=openstack
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc.amqp
-#
-
-# Use durable queues in amqp. (boolean value)
-# Deprecated group/name - [DEFAULT]/rabbit_durable_queues
-#amqp_durable_queues=false
-
-# Auto-delete queues in amqp. (boolean value)
-#amqp_auto_delete=false
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc.impl_kombu
-#
-
-# If SSL is enabled, the SSL version to use. Valid values are
-# TLSv1, SSLv23 and SSLv3. SSLv2 might be available on some
-# distributions. (string value)
-#kombu_ssl_version=
-
-# SSL key file (valid only if SSL enabled) (string value)
-#kombu_ssl_keyfile=
-
-# SSL cert file (valid only if SSL enabled) (string value)
-#kombu_ssl_certfile=
-
-# SSL certification authority file (valid only if SSL enabled)
-# (string value)
-#kombu_ssl_ca_certs=
-
-# The RabbitMQ broker address where a single node is used
-# (string value)
-rabbit_host=<%= @rabbit_settings[:address] %>
-
-# The RabbitMQ broker port where a single node is used
-# (integer value)
-rabbit_port=<%= @rabbit_settings[:port] %>
-
-# RabbitMQ HA cluster host:port pairs (list value)
-#rabbit_hosts=$rabbit_host:$rabbit_port
-
-# Connect over SSL for RabbitMQ (boolean value)
-#rabbit_use_ssl=false
-
-# The RabbitMQ userid (string value)
-rabbit_userid=<%= @rabbit_settings[:user] %>
-
-# The RabbitMQ password (string value)
-rabbit_password=<%= @rabbit_settings[:password] %>
-
-# The RabbitMQ virtual host (string value)
-rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
-
-# How frequently to retry connecting with RabbitMQ (integer
-# value)
-#rabbit_retry_interval=1
-
-# How long to backoff for between retries when connecting to
-# RabbitMQ (integer value)
-#rabbit_retry_backoff=2
-
-# Maximum number of RabbitMQ connection retries. Default is 0
-# (infinite retry count) (integer value)
-#rabbit_max_retries=0
-
-# Use HA queues in RabbitMQ (x-ha-policy: all). If you change
-# this option, you must wipe the RabbitMQ database. (boolean
-# value)
-#rabbit_ha_queues=false
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc.impl_qpid
-#
-
-# Qpid broker hostname (string value)
-#qpid_hostname=localhost
-
-# Qpid broker port (integer value)
-#qpid_port=5672
-
-# Qpid HA cluster host:port pairs (list value)
-#qpid_hosts=$qpid_hostname:$qpid_port
-
-# Username for qpid connection (string value)
-#qpid_username=
-
-# Password for qpid connection (string value)
-#qpid_password=
-
-# Space separated list of SASL mechanisms to use for auth
-# (string value)
-#qpid_sasl_mechanisms=
-
-# Seconds between connection keepalive heartbeats (integer
-# value)
-#qpid_heartbeat=60
-
-# Transport to use, either 'tcp' or 'ssl' (string value)
-#qpid_protocol=tcp
-
-# Disable Nagle algorithm (boolean value)
-#qpid_tcp_nodelay=true
-
-# The qpid topology version to use.  Version 1 is what was
-# originally used by impl_qpid.  Version 2 includes some
-# backwards-incompatible changes that allow broker federation
-# to work.  Users should update to version 2 when they are
-# able to take everything down, as it requires a clean break.
-# (integer value)
-#qpid_topology_version=1
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc.impl_zmq
-#
-
-# ZeroMQ bind address. Should be a wildcard (*), an ethernet
-# interface, or IP. The "host" option should point or resolve
-# to this address. (string value)
-#rpc_zmq_bind_address=*
-
-# MatchMaker driver (string value)
-#rpc_zmq_matchmaker=oslo.messaging._drivers.matchmaker.MatchMakerLocalhost
-
-# ZeroMQ receiver listening port (integer value)
-#rpc_zmq_port=9501
-
-# Number of ZeroMQ contexts, defaults to 1 (integer value)
-#rpc_zmq_contexts=1
-
-# Maximum number of ingress messages to locally buffer per
-# topic. Default is unlimited. (integer value)
-#rpc_zmq_topic_backlog=<None>
-
-# Directory for holding IPC sockets (string value)
-#rpc_zmq_ipc_dir=/var/run/openstack
-
-# Name of this node. Must be a valid hostname, FQDN, or IP
-# address. Must match "host" option, if running Nova. (string
-# value)
-#rpc_zmq_host=ceilometer
-
-
-#
-# Options defined in ceilometer.openstack.common.rpc.matchmaker
-#
-
-# Heartbeat frequency (integer value)
-#matchmaker_heartbeat_freq=300
-
-# Heartbeat time-to-live. (integer value)
-#matchmaker_heartbeat_ttl=600
 
 
 #
@@ -502,19 +518,19 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 
 
 #
+# Options defined in ceilometer.profiler.notifications
+#
+
+# Exchange name for DBaaS notifications (string value)
+#trove_control_exchange=trove
+
+
+#
 # Options defined in ceilometer.storage
 #
 
 # DEPRECATED - Database connection string. (string value)
 #database_connection=<None>
-
-
-#
-# Options defined in ceilometer.storage.sqlalchemy.models
-#
-
-# MySQL engine to use. (string value)
-#mysql_engine=InnoDB
 
 
 #
@@ -526,14 +542,6 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 
 
 [alarm]
-
-#
-# Options defined in ceilometer.cli
-#
-
-# Class to launch as alarm evaluation service. (string value)
-#evaluation_service=ceilometer.alarm.service.SingletonAlarmService
-
 
 #
 # Options defined in ceilometer.alarm.notifier.rest
@@ -549,6 +557,9 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # alarm action. (boolean value)
 #rest_notifier_ssl_verify=true
 
+# Number of retries for REST notifier (integer value)
+#rest_notifier_max_retries=0
+
 
 #
 # Options defined in ceilometer.alarm.rpc
@@ -559,7 +570,10 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 #notifier_rpc_topic=alarm_notifier
 
 # The topic that ceilometer uses for alarm partition
-# coordination messages. (string value)
+# coordination messages. DEPRECATED: RPC-based
+# partitionedalarm evaluation service will be removed in Kilo
+# in favour of the default alarm evaluation service using tooz
+# for partitioning. (string value)
 #partition_rpc_topic=alarm_partition_coordination
 
 
@@ -571,7 +585,8 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # pipeline interval for collection of underlying metrics.
 # (integer value)
 # Deprecated group/name - [alarm]/threshold_evaluation_interval
-threshold_evaluation_interval=<%= @alarm_threshold_evaluation_interval %>
+#evaluation_interval=60
+evaluation_interval=<%= @alarm_threshold_evaluation_interval %>
 
 
 #
@@ -580,6 +595,24 @@ threshold_evaluation_interval=<%= @alarm_threshold_evaluation_interval %>
 
 # Record alarm change events. (boolean value)
 #record_history=true
+
+# Maximum number of alarms defined for a user. (integer value)
+#user_alarm_quota=<None>
+
+# Maximum number of alarms defined for a project. (integer
+# value)
+#project_alarm_quota=<None>
+
+
+#
+# Options defined in ceilometer.cmd.alarm
+#
+
+# Driver to use for alarm evaluation service. DEPRECATED:
+# "singleton" and "partitioned" alarm evaluator services will
+# be removed in Kilo in favour of the default alarm evaluation
+# service using tooz for partitioning. (string value)
+#evaluation_service=default
 
 
 [api]
@@ -596,6 +629,35 @@ port=<%= @bind_port %>
 host=<%= @bind_host %>
 
 
+# Set it to False if your environment does not need or have
+# dns server, otherwise it will delay the response from api.
+# (boolean value)
+#enable_reverse_dns_lookup=false
+
+
+#
+# Options defined in ceilometer.api.app
+#
+
+# Toggle Pecan Debug Middleware. Defaults to global debug
+# value. (boolean value)
+#pecan_debug=false
+
+
+[central]
+
+#
+# Options defined in ceilometer.central.manager
+#
+
+# Work-load partitioning group prefix. Use only if you want to
+# run multiple central agents with different config files. For
+# each sub-group of the central agent pool with the same
+# partitioning_group_prefix a disjoint subset of pollsters
+# should be loaded. (string value)
+#partitioning_group_prefix=<None>
+
+
 [collector]
 
 #
@@ -609,84 +671,146 @@ host=<%= @bind_host %>
 # Port to which the UDP socket is bound. (integer value)
 #udp_port=4952
 
+# Requeue the sample on the collector sample queue when the
+# collector fails to dispatch it. This is only valid if the
+# sample come from the notifier publisher (boolean value)
+#requeue_sample_on_dispatcher_error=false
+
+
+[compute]
+
+#
+# Options defined in ceilometer.compute.discovery
+#
+
+# Enable work-load partitioning, allowing multiple compute
+# agents to be run simultaneously. (boolean value)
+#workload_partitioning=false
+
+
+[coordination]
+
+#
+# Options defined in ceilometer.coordination
+#
+
+# The backend URL to use for distributed coordination. If left
+# empty, per-deployment central agent and per-host compute
+# agent won't do workload partitioning and will only function
+# correctly if a single instance of that service is running.
+# (string value)
+#backend_url=<None>
+
+# Number of seconds between heartbeats for distributed
+# coordination (float) (floating point value)
+#heartbeat=1.0
+
 
 [database]
 
 #
-# Options defined in ceilometer.openstack.common.db.api
+# Options defined in oslo.db
 #
 
-# The backend to use for db (string value)
+# The file name to use with SQLite. (string value)
+#sqlite_db=oslo.sqlite
+
+# If True, SQLite uses synchronous mode. (boolean value)
+#sqlite_synchronous=true
+
+# The back end to use for the database. (string value)
 # Deprecated group/name - [DEFAULT]/db_backend
 #backend=sqlalchemy
 
-
-#
-# Options defined in ceilometer.openstack.common.db.sqlalchemy.session
-#
-
-# The SQLAlchemy connection string used to connect to the
-# database (string value)
+# The SQLAlchemy connection string to use to connect to the
+# database. (string value)
 # Deprecated group/name - [DEFAULT]/sql_connection
 # Deprecated group/name - [DATABASE]/sql_connection
 # Deprecated group/name - [sql]/connection
 connection=<%= @database_connection %>
 
-# The SQLAlchemy connection string used to connect to the
-# slave database (string value)
+# The SQLAlchemy connection string to use to connect to the
+# slave database. (string value)
 #slave_connection=<None>
 
-# Timeout before idle sql connections are reaped (integer
+# The SQL mode to be used for MySQL sessions. This option,
+# including the default, overrides any server-set SQL mode. To
+# use whatever SQL mode is set by the server configuration,
+# set this to no value. Example: mysql_sql_mode= (string
+# value)
+#mysql_sql_mode=TRADITIONAL
+
+# Timeout before idle SQL connections are reaped. (integer
 # value)
 # Deprecated group/name - [DEFAULT]/sql_idle_timeout
 # Deprecated group/name - [DATABASE]/sql_idle_timeout
 # Deprecated group/name - [sql]/idle_timeout
 #idle_timeout=3600
 
-# Minimum number of SQL connections to keep open in a pool
+# Minimum number of SQL connections to keep open in a pool.
 # (integer value)
 # Deprecated group/name - [DEFAULT]/sql_min_pool_size
 # Deprecated group/name - [DATABASE]/sql_min_pool_size
 #min_pool_size=1
 
-# Maximum number of SQL connections to keep open in a pool
+# Maximum number of SQL connections to keep open in a pool.
 # (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_pool_size
 # Deprecated group/name - [DATABASE]/sql_max_pool_size
 #max_pool_size=<None>
 
-# Maximum db connection retries during startup. (setting -1
-# implies an infinite retry count) (integer value)
+# Maximum db connection retries during startup. Set to -1 to
+# specify an infinite retry count. (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_retries
 # Deprecated group/name - [DATABASE]/sql_max_retries
 #max_retries=10
 
-# Interval between retries of opening a sql connection
+# Interval between retries of opening a SQL connection.
 # (integer value)
 # Deprecated group/name - [DEFAULT]/sql_retry_interval
 # Deprecated group/name - [DATABASE]/reconnect_interval
 #retry_interval=10
 
-# If set, use this value for max_overflow with sqlalchemy
+# If set, use this value for max_overflow with SQLAlchemy.
 # (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_overflow
 # Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
 #max_overflow=<None>
 
-# Verbosity of SQL debugging information. 0=None,
-# 100=Everything (integer value)
+# Verbosity of SQL debugging information: 0=None,
+# 100=Everything. (integer value)
 # Deprecated group/name - [DEFAULT]/sql_connection_debug
 #connection_debug=0
 
-# Add python stack traces to SQL as comment strings (boolean
+# Add Python stack traces to SQL as comment strings. (boolean
 # value)
 # Deprecated group/name - [DEFAULT]/sql_connection_trace
 #connection_trace=false
 
-# If set, use this value for pool_timeout with sqlalchemy
+# If set, use this value for pool_timeout with SQLAlchemy.
 # (integer value)
 # Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
 #pool_timeout=<None>
+
+# Enable the experimental use of database reconnect on
+# connection lost. (boolean value)
+#use_db_reconnect=false
+
+# Seconds between database connection retries. (integer value)
+#db_retry_interval=1
+
+# If True, increases the interval between database connection
+# retries up to db_max_retry_interval. (boolean value)
+#db_inc_retry_interval=true
+
+# If db_inc_retry_interval is set, the maximum seconds between
+# database connection retries. (integer value)
+#db_max_retry_interval=10
+
+# Maximum database connection retries before error is raised.
+# Set to -1 to specify an infinite retry count. (integer
+# value)
+#db_max_retries=20
 
 
 #
@@ -696,6 +820,14 @@ connection=<%= @database_connection %>
 # Number of seconds that samples are kept in the database for
 # (<= 0 means forever). (integer value)
 time_to_live=<%= @time_to_live %>
+
+# The connection string used to connect to the meteting
+# database. (if unset, connection is used) (string value)
+#metering_connection=<None>
+
+# The connection string used to connect to the alarm database.
+# (if unset, connection is used) (string value)
+#alarm_connection=<None>
 
 
 [dispatcher_file]
@@ -730,57 +862,52 @@ time_to_live=<%= @time_to_live %>
 #drop_unmatched_notifications=false
 
 
+[hardware]
+
+#
+# Options defined in ceilometer.hardware.discovery
+#
+
+# URL scheme to use for hardware nodes (string value)
+#url_scheme=snmp://
+
+# SNMPd user name of all nodes running in the cloud. (string
+# value)
+#readonly_user_name=ro_snmp_user
+
+# SNMPd password of all the nodes running in the cloud (string
+# value)
+#readonly_user_password=password
+
+
+[ipmi]
+
+#
+# Options defined in ceilometer.ipmi.platform.intel_node_manager
+#
+
+# Number of retries upon Intel Node Manager initialization
+# failure (integer value)
+#node_manager_init_retry=3
+
+
 [keystone_authtoken]
 
 #
-# Options defined in keystoneclient.middleware.auth_token
+# Options defined in keystonemiddleware.auth_token
 #
 
-# Prefix to prepend at the beginning of the path (string
-# value)
-#auth_admin_prefix=
-
-# Host providing the admin Identity API endpoint (string
-# value)
-auth_host=<%= @keystone_settings['internal_url_host'] %>
-
-# Port of the admin Identity API endpoint (integer value)
-auth_port=<%= @keystone_settings['admin_port'] %>
-
-# Protocol of the admin Identity API endpoint(http or https)
-# (string value)
-auth_protocol= <%= @keystone_settings['protocol'] %>
-
-# Complete public Identity API endpoint (string value)
+# Complete public Identity API endpoint. (string value)
 auth_uri=<%= @keystone_settings['internal_auth_url'] %>
 
-# API version of the admin Identity API endpoint (string
+# Complete admin Identity API endpoint. This should specify
+# the unversioned root endpoint e.g. https://localhost:35357/
+# (string value)
+identity_uri = <%= @keystone_settings['admin_auth_url'] %>
+
+# API version of the admin Identity API endpoint. (string
 # value)
 #auth_version=<None>
-
-# Do not handle authorization requests within the middleware,
-# but delegate the authorization decision to downstream WSGI
-# components (boolean value)
-#delay_auth_decision=false
-
-# Request timeout value for communicating with Identity API
-# server. (boolean value)
-#http_connect_timeout=<None>
-
-# How many times are we trying to reconnect when communicating
-# with Identity API Server. (integer value)
-#http_request_max_retries=3
-
-# Allows to pass in the name of a fake http_handler callback
-# function used instead of httplib.HTTPConnection or
-# httplib.HTTPSConnection. Useful for unit testing where
-# network is not available. (string value)
-#http_handler=<None>
-
-# Single shared secret with the Keystone configuration used
-# for bootstrapping a Keystone installation, or otherwise
-# bypassing the normal authentication process. (string value)
-#admin_token=<None>
 
 # Keystone account username (string value)
 admin_user=<%= @keystone_settings['service_user'] %>
@@ -792,14 +919,27 @@ admin_password=<%= @keystone_settings['service_password'] %>
 # (string value)
 admin_tenant_name=<%= @keystone_settings['service_tenant'] %>
 
-# Env key for the swift cache (string value)
+# Do not handle authorization requests within the middleware,
+# but delegate the authorization decision to downstream WSGI
+# components. (boolean value)
+#delay_auth_decision=false
+
+# Request timeout value for communicating with Identity API
+# server. (integer value)
+#http_connect_timeout=<None>
+
+# How many times are we trying to reconnect when communicating
+# with Identity API Server. (integer value)
+#http_request_max_retries=3
+
+# Env key for the swift cache. (string value)
 #cache=<None>
 
-# Required if Keystone server requires client certificate
+# Required if identity server requires client certificate
 # (string value)
 #certfile=<None>
 
-# Required if Keystone server requires client certificate
+# Required if identity server requires client certificate
 # (string value)
 #keyfile=<None>
 
@@ -808,6 +948,7 @@ admin_tenant_name=<%= @keystone_settings['service_tenant'] %>
 #cafile=<None>
 
 # Verify HTTPS connections. (boolean value)
+#insecure=false
 <% if @keystone_settings['insecure'] -%>
 insecure = <%= @keystone_settings['insecure'] %>
 <% end -%>
@@ -816,16 +957,16 @@ insecure = <%= @keystone_settings['insecure'] %>
 # value)
 signing_dir=/var/cache/ceilometer/keystone-signing
 
-# If defined, the memcache server(s) to use for caching (list
-# value)
+# Optionally specify a list of memcached server(s) to use for
+# caching. If left undefined, tokens will instead be cached
+# in-process. (list value)
 # Deprecated group/name - [DEFAULT]/memcache_servers
 #memcached_servers=<None>
 
-# In order to prevent excessive requests and validations, the
-# middleware uses an in-memory cache for the tokens the
-# Keystone API returns. This is only valid if memcache_servers
-# is defined. Set to -1 to disable caching completely.
-# (integer value)
+# In order to prevent excessive effort spent validating
+# tokens, the middleware caches previously-seen tokens for a
+# configurable duration (in seconds). Set to -1 to disable
+# caching completely. (integer value)
 #token_cache_time=300
 
 # Determines the frequency at which the list of revoked tokens
@@ -835,8 +976,7 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 # value)
 #revocation_cache_time=10
 
-
-# (optional) if defined, indicate whether token data should be
+# (Optional) If defined, indicate whether token data should be
 # authenticated or authenticated and encrypted. Acceptable
 # values are MAC or ENCRYPT.  If MAC, token data is
 # authenticated (with HMAC) in the cache. If ENCRYPT, token
@@ -845,12 +985,38 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 # raise an exception on initialization. (string value)
 #memcache_security_strategy=<None>
 
-# (optional, mandatory if memcache_security_strategy is
-# defined) this string is used for key derivation. (string
+# (Optional, mandatory if memcache_security_strategy is
+# defined) This string is used for key derivation. (string
 # value)
 #memcache_secret_key=<None>
 
-# (optional) indicate whether to set the X-Service-Catalog
+# (Optional) Number of seconds memcached server is considered
+# dead before it is tried again. (integer value)
+#memcache_pool_dead_retry=300
+
+# (Optional) Maximum total number of open connections to every
+# memcached server. (integer value)
+#memcache_pool_maxsize=10
+
+# (Optional) Socket timeout in seconds for communicating with
+# a memcache server. (integer value)
+#memcache_pool_socket_timeout=3
+
+# (Optional) Number of seconds a connection to memcached is
+# held unused in the pool before it is closed. (integer value)
+#memcache_pool_unused_timeout=60
+
+# (Optional) Number of seconds that an operation will wait to
+# get a memcache client connection from the pool. (integer
+# value)
+#memcache_pool_conn_get_timeout=10
+
+# (Optional) Use the advanced (eventlet safe) memcache client
+# pool. The advanced pool will only work under python 2.x.
+# (boolean value)
+#memcache_use_advanced_pool=false
+
+# (Optional) Indicate whether to set the X-Service-Catalog
 # header. If False, middleware will not ask for service
 # catalog on token validation and will not set the X-Service-
 # Catalog header. (boolean value)
@@ -867,30 +1033,47 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 # value)
 #enforce_token_bind=permissive
 
+# If true, the revocation list will be checked for cached
+# tokens. This requires that PKI tokens are configured on the
+# identity server. (boolean value)
+#check_revocations_for_cached=false
+
+# Hash algorithms to use for hashing PKI tokens. This may be a
+# single algorithm or multiple. The algorithms are those
+# supported by Python standard hashlib.new(). The hashes will
+# be tried in the order given, so put the preferred one first
+# for performance. The result of the first hash will be stored
+# in the cache. This will typically be set to multiple values
+# only while migrating from a less secure algorithm to a more
+# secure one. Once all the old tokens are expired this option
+# should be set to a single value for better performance.
+# (list value)
+#hash_algorithms=md5
+
 
 [matchmaker_redis]
 
 #
-# Options defined in ceilometer.openstack.common.rpc.matchmaker_redis
+# Options defined in oslo.messaging
 #
 
-# Host to locate redis (string value)
+# Host to locate redis. (string value)
 #host=127.0.0.1
 
 # Use this port to connect to redis host. (integer value)
 #port=6379
 
-# Password for Redis server. (optional) (string value)
+# Password for Redis server (optional). (string value)
 #password=<None>
 
 
 [matchmaker_ring]
 
 #
-# Options defined in ceilometer.openstack.common.rpc.matchmaker_ring
+# Options defined in oslo.messaging
 #
 
-# Matchmaker ring file (JSON) (string value)
+# Matchmaker ring file (JSON). (string value)
 # Deprecated group/name - [DEFAULT]/matchmaker_ringfile
 #ringfile=/etc/oslo/matchmaker_ring.json
 
@@ -908,6 +1091,59 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 # Save event details. (boolean value)
 #store_events=false
 
+# Messaging URLs to listen for notifications. Example:
+# transport://user:pass@host1:port[,hostN:portN]/virtual_host
+# (DEFAULT/transport_url is used if empty) (multi valued)
+#messaging_urls=
+
+
+[oslo_messaging_amqp]
+
+#
+# Options defined in oslo.messaging
+#
+
+# address prefix used when sending to a specific server
+# (string value)
+#server_request_prefix=exclusive
+
+# address prefix used when broadcasting to all servers (string
+# value)
+#broadcast_prefix=broadcast
+
+# address prefix when sending to any server in group (string
+# value)
+#group_request_prefix=unicast
+
+# Name for the AMQP container (string value)
+#container_name=<None>
+
+# Timeout for inactive connections (in seconds) (integer
+# value)
+#idle_timeout=0
+
+# Debug: dump AMQP frames to stdout (boolean value)
+#trace=false
+
+# CA certificate PEM file for verifing server certificate
+# (string value)
+#ssl_ca_file=
+
+# Identifying certificate PEM file to present to clients
+# (string value)
+#ssl_cert_file=
+
+# Private key PEM file used to sign cert_file certificate
+# (string value)
+#ssl_key_file=
+
+# Password for decrypting ssl_key_file (if encrypted) (string
+# value)
+#ssl_key_password=<None>
+
+# Accept clients using either SSL or plain TCP (boolean value)
+#allow_insecure_clients=false
+
 
 [publisher]
 
@@ -921,10 +1157,25 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 metering_secret=<%= @metering_secret %>
 
 
+[publisher_notifier]
+
+#
+# Options defined in ceilometer.publisher.messaging
+#
+
+# The topic that ceilometer uses for metering notifications.
+# (string value)
+#metering_topic=metering
+
+# The driver that ceilometer uses for metering notifications.
+# (string value)
+#metering_driver=messagingv2
+
+
 [publisher_rpc]
 
 #
-# Options defined in ceilometer.publisher.rpc
+# Options defined in ceilometer.publisher.messaging
 #
 
 # The topic that ceilometer uses for metering messages.
@@ -932,21 +1183,12 @@ metering_secret=<%= @metering_secret %>
 #metering_topic=metering
 
 
-[rpc_notifier2]
-
-#
-# Options defined in ceilometer.openstack.common.notifier.rpc_notifier2
-#
-
-# AMQP topic(s) used for OpenStack notifications (list value)
-#topics=notifications
-
-
 [service_credentials]
 
 #
 # Options defined in ceilometer.service
 #
+
 
 # User name to use for OpenStack service access. (string
 # value)
@@ -982,23 +1224,46 @@ os_endpoint_type=internalURL
 insecure= <%= @keystone_settings['insecure'] %>
 
 
-[ssl]
+[service_types]
 
 #
-# Options defined in ceilometer.openstack.common.sslutils
+# Options defined in ceilometer.neutron_client
 #
 
-# CA certificate file to use to verify connecting clients
-# (string value)
-#ca_file=<None>
+# Neutron service type. (string value)
+#neutron=network
 
-# Certificate file to use when starting the server securely
-# (string value)
-#cert_file=<None>
 
-# Private key file to use when starting the server securely
-# (string value)
-#key_file=<None>
+#
+# Options defined in ceilometer.nova_client
+#
+
+# Nova service type. (string value)
+#nova=compute
+
+
+#
+# Options defined in ceilometer.energy.kwapi
+#
+
+# Kwapi service type. (string value)
+#kwapi=energy
+
+
+#
+# Options defined in ceilometer.image.glance
+#
+
+# Glance service type. (string value)
+#glance=image
+
+
+#
+# Options defined in ceilometer.objectstore.swift
+#
+
+# Swift service type. (string value)
+#swift=object-store
 
 
 [vmware]
@@ -1023,5 +1288,32 @@ host_password=<%= node[:nova][:vcenter][:password] rescue "" %>
 # Sleep time in seconds for polling an ongoing async task
 # (floating point value)
 #task_poll_interval=0.5
+
+# Optional vim service WSDL location e.g
+# http://<server>/vimService.wsdl. Optional over-ride to
+# default location for bug work-arounds (string value)
+#wsdl_location=<None>
+
+
+[xenapi]
+
+#
+# Options defined in ceilometer.compute.virt.xenapi.inspector
+#
+
+# URL for connection to XenServer/Xen Cloud Platform (string
+# value)
+#connection_url=<None>
+
+# Username for connection to XenServer/Xen Cloud Platform
+# (string value)
+#connection_username=root
+
+# Password for connection to XenServer/Xen Cloud Platform
+# (string value)
+#connection_password=<None>
+
+# Timeout in seconds for XenAPI login. (integer value)
+#login_timeout=10
 
 

--- a/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
+++ b/chef/cookbooks/ceilometer/templates/default/ceilometer.conf.erb
@@ -197,7 +197,7 @@ use_stderr=false
 #logging_exception_prefix=%(asctime)s.%(msecs)03d %(process)d TRACE %(name)s %(instance)s
 
 # List of logger=LEVEL pairs (list value)
-#default_log_levels=amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN
+#default_log_levels=amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN
 
 # Publish error events (boolean value)
 #publish_errors=false
@@ -461,7 +461,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 #rpc_zmq_bind_address=*
 
 # MatchMaker driver (string value)
-#rpc_zmq_matchmaker=ceilometer.openstack.common.rpc.matchmaker.MatchMakerLocalhost
+#rpc_zmq_matchmaker=oslo.messaging._drivers.matchmaker.MatchMakerLocalhost
 
 # ZeroMQ receiver listening port (integer value)
 #rpc_zmq_port=9501
@@ -634,7 +634,7 @@ connection=<%= @database_connection %>
 
 # The SQLAlchemy connection string used to connect to the
 # slave database (string value)
-#slave_connection=
+#slave_connection=<None>
 
 # Timeout before idle sql connections are reaped (integer
 # value)
@@ -828,8 +828,13 @@ signing_dir=/var/cache/ceilometer/keystone-signing
 # (integer value)
 #token_cache_time=300
 
-# Value only used for unit testing (integer value)
-#revocation_cache_time=1
+# Determines the frequency at which the list of revoked tokens
+# is retrieved from the Identity service (in seconds). A high
+# number of revocation events combined with a low cache
+# duration may significantly reduce performance. (integer
+# value)
+#revocation_cache_time=10
+
 
 # (optional) if defined, indicate whether token data should be
 # authenticated or authenticated and encrypted. Acceptable

--- a/chef/cookbooks/ceilometer/templates/default/pipeline.yaml.erb
+++ b/chef/cookbooks/ceilometer/templates/default/pipeline.yaml.erb
@@ -34,7 +34,7 @@ sinks:
     - name: meter_sink
       transformers:
       publishers:
-          - rpc://
+          - notifier://
     - name: cpu_sink
       transformers:
           - name: "rate_of_change"
@@ -45,7 +45,7 @@ sinks:
                     type: "gauge"
                     scale: "100.0 / (10**9 * (resource_metadata.cpu_number or 1))"
       publishers:
-          - rpc://
+          - notifier://
     - name: disk_sink
       transformers:
           - name: "rate_of_change"
@@ -60,7 +60,7 @@ sinks:
                         unit: "\\1/s"
                     type: "gauge"
       publishers:
-          - rpc://
+          - notifier://
     - name: network_sink
       transformers:
           - name: "rate_of_change"
@@ -75,4 +75,4 @@ sinks:
                         unit: "\\1/s"
                     type: "gauge"
       publishers:
-          - rpc://
+          - notifier://


### PR DESCRIPTION
1. pipeline change: https://github.com/openstack/ceilometer/commit/fec77dbc85fed701fdbc3a96bae57e5ae3a705cb

2. ceilometer.conf changes based on http://docs.openstack.org/juno/config-reference/content/ceilometer-conf-changes-juno.html

3. Other keys that are now missing, but not mentioned in the link above: 
 ``auth_host auth_port auth_protocol`` - I expect ``auth_uri`` is enough
 ``admin_user admin_password admin_tenant_name``