### PR TITLE
Switch to standard database by default

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -58,7 +58,7 @@ default["ceilometer"]["alarm_notifier"]["service_name"] = alarm_notifier_service
 default[:ceilometer][:debug] = false
 default[:ceilometer][:verbose] = false
 
-default[:ceilometer][:use_mongodb] = true
+default[:ceilometer][:use_mongodb] = false
 
 default[:ceilometer][:meters_interval] = 600
 default[:ceilometer][:cpu_interval] = 600

--- a/chef/data_bags/crowbar/bc-template-ceilometer.json
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.json
@@ -5,7 +5,7 @@
     "ceilometer": {
       "debug": false,
       "verbose": true,
-      "use_mongodb": true,
+      "use_mongodb": false,
       "alarm_threshold_evaluation_interval": 600,
       "cpu_interval": 600,
       "disk_interval": 600,


### PR DESCRIPTION
Juno seems to be reasonably good with PostgreSQL support and
we have quite some unresolved security and maintenance issues
with mongodb.