### PR TITLE
Support ceilometer-agent role deployemt on hyperv nodes

### DIFF
--- a/chef/cookbooks/ceilometer/attributes/default.rb
+++ b/chef/cookbooks/ceilometer/attributes/default.rb
@@ -73,6 +73,7 @@ default[:ceilometer][:service_user] = "ceilometer"
 default[:ceilometer][:service_password] = ""
 
 default[:ceilometer][:api][:protocol] = "http"
+default[:ceilometer][:api][:host] = "0.0.0.0"
 default[:ceilometer][:api][:port] = 8777
 
 default[:ceilometer][:metering_secret] = "" # Set by wrapper

--- a/chef/cookbooks/ceilometer/recipes/common.rb
+++ b/chef/cookbooks/ceilometer/recipes/common.rb
@@ -66,7 +66,7 @@ if node[:ceilometer][:ha][:server][:enabled]
   bind_host = admin_address
   bind_port = node[:ceilometer][:ha][:ports][:api]
 else
-  bind_host = "0.0.0.0"
+  bind_host = node[:ceilometer][:api][:host]
   bind_port = node[:ceilometer][:api][:port]
 end
 

--- a/chef/data_bags/crowbar/bc-template-ceilometer.json
+++ b/chef/data_bags/crowbar/bc-template-ceilometer.json
@@ -40,6 +40,7 @@
         "ceilometer-server": [ "readying", "ready", "applying" ],
         "ceilometer-cagent": [ "readying", "ready", "applying" ],
         "ceilometer-agent": [ "readying", "ready", "applying" ],
+        "ceilometer-agent-hyperv": [ "readying", "ready", "applying" ],
         "ceilometer-swift-proxy-middleware": [ "readying", "ready", "applying" ]
       },
       "elements": {},
@@ -47,12 +48,14 @@
         [ "ceilometer-server" ],
         [ "ceilometer-cagent" ], 
         [ "ceilometer-agent" ],
+        [ "ceilometer-agent-hyperv" ],
         [ "ceilometer-swift-proxy-middleware" ]
       ],
       "element_run_list_order": {
         "ceilometer-server": 101,
         "ceilometer-cagent": 102,
         "ceilometer-agent": 103,
+        "ceilometer-agent-hyperv": 104,
         "ceilometer-swift-proxy-middleware" : 80
       },
       "config": {

--- a/chef/data_bags/crowbar/migrate/ceilometer/014_add_ceilometer-agent-hyperv_role.rb
+++ b/chef/data_bags/crowbar/migrate/ceilometer/014_add_ceilometer-agent-hyperv_role.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+  return a, d
+end

--- a/chef/roles/ceilometer-agent-hyperv.rb
+++ b/chef/roles/ceilometer-agent-hyperv.rb
@@ -1,0 +1,9 @@
+name "ceilometer-agent-hyperv"
+description "Ceilometer Agent Role on HyperV Hosts"
+run_list(
+         "recipe[hyperv::do_setup]",
+         "recipe[hyperv::do_ceilometer]"
+)
+default_attributes()
+override_attributes()
+

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -37,6 +37,13 @@ class CeilometerService < PacemakerServiceObject
             "windows" => "/.*/"
           }
         },
+        "ceilometer-agent-hyperv" => {
+          "unique" => false,
+          "count" => -1,
+          "platform" => {
+            "windows" => "/.*/"
+          }
+        },
         "ceilometer-cagent" => {
           "unique" => false,
           "count" => 1,
@@ -90,6 +97,8 @@ class CeilometerService < PacemakerServiceObject
       NodeObject.find("roles:nova-multi-compute-vmware") +
       NodeObject.find("roles:nova-multi-compute-xen")
 
+    hyperv_agent_nodes = NodeObject.find("roles:nova-multi-compute-hyperv")
+
     nodes       = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
 
@@ -100,6 +109,7 @@ class CeilometerService < PacemakerServiceObject
 
     base["deployment"]["ceilometer"]["elements"] = {
         "ceilometer-agent" => agent_nodes.map { |x| x.name },
+        "ceilometer-agent-hyperv" => hyperv_agent_nodes.map { |x| x.name },
         "ceilometer-cagent" => [ server_nodes.first.name ],
         "ceilometer-server" => [ server_nodes.first.name ],
         "ceilometer-swift-proxy-middleware" => swift_proxy_nodes.map { |x| x.name }
@@ -118,6 +128,10 @@ class CeilometerService < PacemakerServiceObject
     validate_one_for_role proposal, "ceilometer-server"
 
     validate_minimum_three_nodes_in_cluster(proposal)
+
+    unless proposal["deployment"]["ceilometer"]["elements"]["ceilometer-agent-hyperv"].empty? || hyperv_available?
+      validation_error("Hyper-V support is not available.")
+    end
 
     swift_proxy_nodes = NodeObject.find("roles:swift-proxy").map { |x| x.name }
     if proposal["deployment"]["ceilometer"]["elements"]["ceilometer-swift-proxy-middleware"]
@@ -141,6 +155,10 @@ class CeilometerService < PacemakerServiceObject
   def apply_role_pre_chef_call(old_role, role, all_nodes)
     @logger.debug("Ceilometer apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     return if all_nodes.empty?
+
+    unless hyperv_available?
+      role.override_attributes["ceilometer"]["elements"]["ceilometer-hyperv-agent"] = []
+    end
 
     server_elements, server_nodes, ha_enabled = role_expand_elements(role, "ceilometer-server")
 
@@ -239,4 +257,9 @@ class CeilometerService < PacemakerServiceObject
         ) if nodes.length < 3
     end
   end
+
+  def hyperv_available?
+    return File.exist?('/opt/dell/chef/cookbooks/hyperv')
+  end
+
 end


### PR DESCRIPTION
Create role ceilometer-agent-hypev, adjust barclamp and
add a migration

**Note:** Depends on https://github.com/crowbar/barclamp-hyperv-compute/pull/32