### PR TITLE
Allow deploying ceilometer-cagent on SLE12 nodes

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -41,7 +41,6 @@ class CeilometerService < PacemakerServiceObject
           "unique" => false,
           "count" => 1,
           "exclude_platform" => {
-            "suse" => "12.0",
             "windows" => "/.*/"
           },
           "cluster" => true


### PR DESCRIPTION
This seems to just work fine.