### PR TITLE
[WIP] Allow deploying remaining ceilometer roles on SLE12 nodes

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -56,7 +56,6 @@ class CeilometerService < PacemakerServiceObject
           "unique" => false,
           "count" => 1,
           "exclude_platform" => {
-            "suse" => "12.0",
             "windows" => "/.*/"
           },
           "cluster" => true

--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -65,7 +65,6 @@ class CeilometerService < PacemakerServiceObject
           "unique" => false,
           "count" => -1,
           "exclude_platform" => {
-            "suse" => "12.0",
             "windows" => "/.*/"
           }
         }


### PR DESCRIPTION
This depends on https://github.com/crowbar/barclamp-swift/pull/288

For the ceilometer-server part: **untested with mongodb** (due to missing package right now).