### PR TITLE
Do not assume ceilometer-agent-hyperv is listed in elements (bsc#937117)

### DIFF
--- a/crowbar_framework/app/models/ceilometer_service.rb
+++ b/crowbar_framework/app/models/ceilometer_service.rb
@@ -137,7 +137,7 @@ class CeilometerService < PacemakerServiceObject
 
     validate_minimum_three_nodes_in_cluster(proposal)
 
-    unless proposal["deployment"]["ceilometer"]["elements"]["ceilometer-agent-hyperv"].empty? || hyperv_available?
+    unless (proposal["deployment"]["ceilometer"]["elements"]["ceilometer-agent-hyperv"] || []).empty? || hyperv_available?
       validation_error("Hyper-V support is not available.")
     end
 


### PR DESCRIPTION
Backport of https://github.com/crowbar/barclamp-ceilometer/pull/201

This is not always the case, especially on upgrades (but this could also
be removed manually from the json).

https://bugzilla.suse.com/show_bug.cgi?id=937117
(cherry picked from commit 7822b4b3fa4c3c62db3964e0b404cef3e61e9bbd)