### PR TITLE
[stoney] increase timeout for synchronization of HA resources (bsc#935462)

### DIFF
--- a/chef/cookbooks/ceilometer/recipes/server_ha.rb
+++ b/chef/cookbooks/ceilometer/recipes/server_ha.rb
@@ -27,7 +27,9 @@ end.run_action(:create)
 crowbar_pacemaker_sync_mark "sync-ceilometer_server_before_ha"
 
 # Avoid races when creating pacemaker resources
-crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources"
+crowbar_pacemaker_sync_mark "wait-ceilometer_server_ha_resources" do
+  timeout 120
+end
 
 primitives = []
 


### PR DESCRIPTION
(backport of #204 to stoney)

Ceilometer HA resources can take over 1 minute to be set up, as seen by
mkcloud failures in ci.suse.de Jenkins.

https://bugzilla.suse.com/show_bug.cgi?id=935462

(cherry picked from commit 7b7cd2b571b2e7b0416bf22a9e6fdd5b04129fe4)